### PR TITLE
Fix x265 typo.

### DIFF
--- a/_posts/user_guide/0000-02-05-features.md
+++ b/_posts/user_guide/0000-02-05-features.md
@@ -115,7 +115,7 @@ category: 2
         <p hidden>digiKam</p>        <td>❔</td>
     </tr>
     <tr>
-        <td>x256 videos</td>
+        <td>x265 videos</td>
         <p hidden>LibrePhotos</p>    <td>❌</td>
         <p hidden>Photoview</p>      <td>✔️</td>
         <p hidden>PhotoPrism</p>     <td>✔️</td>


### PR DESCRIPTION
Typo with the video format name.
[Wikipedia x265](https://en.wikipedia.org/wiki/X265)
