### PR TITLE
Fixing a markdown style link

### DIFF
--- a/docs/user-guide/features.md
+++ b/docs/user-guide/features.md
@@ -257,7 +257,7 @@ sidebar_position: 6
         <p hidden>Immich</p>         <td>❌</td>
         <p hidden>Photonix</p>       <td>✔️</td>
         <p hidden>Damselfly</p>      <td>❔</td>
-        <p hidden>Synology Photos</p><td>✔️ [*](https://kb.synology.com/en-uk/DSM/tutorial/Which_Synology_NAS_models_support_the_facial_recognition_feature_on_Synology_Photos)</td>
+        <p hidden>Synology Photos</p><td>✔️<a href="https://kb.synology.com/en-uk/DSM/tutorial/Which_Synology_NAS_models_support_the_facial_recognition_feature_on_Synology_Photos">*</a></td>
         <p hidden>Lomorage</p>       <td>❔</td>
         <p hidden>Piwigo</p>         <td>❔</td>
         <p hidden>Photostructure</p> <td>❔</td>


### PR DESCRIPTION
Thanks for this really valuable resource! 
Currently the Synology Photos column has a markdown style link rather than a HTML link, which makes the column very wide, and so the table doesn't render nicely. This minor change fixes the link.

![image](https://github.com/LibrePhotos/librephotos.docs/assets/7007561/9a4946f1-5736-4784-adc9-ee0c87be087c)

![image](https://github.com/LibrePhotos/librephotos.docs/assets/7007561/665f7443-8f36-40b7-bd9d-4f9c509d1049)
