### PR TITLE
changed the folder name of the cloned repo to match .env file

### DIFF
--- a/docs/installation/standard-install.md
+++ b/docs/installation/standard-install.md
@@ -19,9 +19,9 @@ models. Librephotos will also create a database and thumbnails, which will need 
 
 ### 🚀 Installation
 
-Clone the repo: `git clone https://github.com/LibrePhotos/librephotos-docker.git`
+Clone the repo: `git clone https://github.com/LibrePhotos/librephotos-docker.git librephotos`
 
-Navigate to the librephotos-docker folder: `cd librephotos-docker`
+Navigate to the librephotos-docker folder: `cd librephotos`
 
 Copy the template variable file (containing options such as the location of your photos): `cp librephotos.env .env`
 
@@ -45,7 +45,7 @@ Next, take a look at the [first steps after setup](../user-guide/first-steps.md)
 
 ### Updating
 
-To update LibrePhotos when using Docker Compose, navigate to the librephotos-docker folder that was created when you installed LibrePhotos.
+To update LibrePhotos when using Docker Compose, navigate to the librephotos folder that was created when you installed LibrePhotos.
 
 Then run:
 


### PR DESCRIPTION
The current instructions will have you clone the repo into a folder called 'librephotos-docker'. 

The .env file however references the './librephotos' folder. This fixes that for users who may not have noticed.

Even the docker run command on this page references the 'librephotos' folder